### PR TITLE
docs: Update Testcontainers language example to start a Redis container

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -54,7 +54,6 @@ sections:
         label: Node.js
         code: |
           ```
-          const { GenericContainer, Wait } = require("testcontainers");
           const redis = await new GenericContainer("redis:5.0.3-alpine")
               .withExposedPorts(6379)
               .withWaitStrategy(Wait.forLogMessage("Ready to accept connections"))


### PR DESCRIPTION
## What does this PR do?

Updates the language examples (except Python and Rust) to start a Redis container.

## Why is it important?

The languages use different configurations. Using the same configuration across all languages might look better. If we should use a different example or another approach lets discuss it here or in the related issue below.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/testcontainers/testcontainers-internal/issues/148

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Follow-ups

I will look into Rust and test if we can use Redis too.