### PR TITLE
chore: run the container for the Go example

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -23,11 +23,14 @@ sections:
         label: Go
         code: |
           ```
-          req := testcontainers.ContainerRequest{
-              Image:        "redis:5.0.3-alpine",
-              ExposedPorts: []string{"6379/tcp"},
-              WaitingFor:   wait.ForLog("Ready to accept connections"),
-          }
+          container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+              ContainerRequest: testcontainers.ContainerRequest{
+                  Image:        "redis:5.0.3-alpine",
+                  ExposedPorts: []string{"6379/tcp"},
+                  WaitingFor:   wait.ForLog("Ready to accept connections"),
+              },
+              Started:          true,
+          })
           ```
       - id: dotnet
         label: .NET


### PR DESCRIPTION
## What does this PR do?
It updates the Go example, declaring the container request and using it to actually run the container

## Why is it important?
All langs describe how to run a container, in Go we described how to define a request. Align for the win! :)
