### PR TITLE
docs: add Redis module for tc-go

### DIFF
--- a/content/modules/redis.md
+++ b/content/modules/redis.md
@@ -15,7 +15,7 @@ docs:
     url: https://golang.testcontainers.org/modules/redis/
     example: |
       ```go
-      redisContainer, err := redis.StartContainer(ctx, WithImage("redis:6"))
+      redisContainer, err := redis.StartContainer(ctx, redis.WithImage("redis:6"))
       ```
   - id: dotnet
     url: https://dotnet.testcontainers.org/modules/


### PR DESCRIPTION
## What does this PR do?
It adds the tc-go's Redis module to the modules page

## Why is it important?
A module a day keeps the bugs away
