### PR TITLE
Filter only supported languages in modules language filter

### DIFF
--- a/layouts/modules/list.html
+++ b/layouts/modules/list.html
@@ -61,19 +61,14 @@
                 </label>
               </div>
               {{ range .Site.Taxonomies.languages }}
-                <div class="filter-field">
-                  <input type="radio" id="language-{{ .Page.Params.slug }}" name="language" class="filter-input sr-only"/>
-                  <label for="language-{{ .Page.Params.slug }}" class="radio-button">
-                    <!--
-                    <div class="checkbox-proxy">
-                      <svg class="icon-check" width="10" height="10" viewBox="0 0 10 10">
-                        <use href="#icon-check"></use>
-                      </svg>
-                    </div>
-                    -->
-                    <span>{{ .Page.Title }}</span>
-                  </label>
-                </div>
+                {{ if in (slice "java" "dotnet" "go" "nodejs") .Page.Params.slug }}
+                  <div class="filter-field">
+                    <input type="radio" id="language-{{ .Page.Params.slug }}" name="language" class="filter-input sr-only"/>
+                    <label for="language-{{ .Page.Params.slug }}" class="radio-button">
+                      <span>{{ .Page.Title }}</span>
+                    </label>
+                  </div>
+                {{ end }}
               {{ end }}
             </div>
             <div class="category-filter">


### PR DESCRIPTION
The modules language filter is populated by the languages taxonomy. This taxonomy is shared between guides and modules so when another language was used for a guide (C#) it appeared in the languages filter. 

I have updated the filter loop to limit the languages displayed to the ones we support for modules.  