### PR TITLE
feat: add k3s module for golang

### DIFF
--- a/content/modules/k3s.md
+++ b/content/modules/k3s.md
@@ -14,7 +14,7 @@ docs:
     url: https://golang.testcontainers.org/modules/k3s/
     example: |
       ```go
-      k3sContainer, err := k3s.RunContainer(ctx, testcontainers.WithImage("docker.io/rancher/k3s:v1.27.1-k3s1"))
+      k3sContainer, err := k3s.RunContainer(ctx, testcontainers.WithImage("rancher/k3s:v1.27.1-k3s1"))
       ```
   - id: dotnet
     url: https://www.nuget.org/packages/Testcontainers.K3s


### PR DESCRIPTION
## What does this PR do?
It adds the k3s module for tc-go, including code snippet and the usage of `WithImage`

## Why is it important?
Keep modules up-to-date

## How to test this?

1. start the web
```shell
sh dev.sh
hugo serve
```
2. Browse the k3s module URL: http://localhost:1313/modules/k3s
3. Check Go is present in the list

