### PR TITLE
Add sitemap

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -26,6 +26,9 @@ paginate = 9999
             iconsdir = "/images/icons"
             icontype = "svg"
 
+[sitemap]
+    filename = 'sitemap.xml'
+
 [security]
     enableInlineShortcodes = false
 

--- a/layouts/_default/sitemap.xml
+++ b/layouts/_default/sitemap.xml
@@ -1,0 +1,24 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{ range where (where site.Pages "Kind" "not in" "[taxonomy, term]")  "Params.sitemap_exclude" "ne" true }}
+    {{- if .Permalink -}}
+  <url>
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+    <xhtml:link
+        rel="alternate"
+        hreflang="{{ .Language.LanguageCode }}"
+        href="{{ .Permalink }}"
+        />{{ end }}
+    <xhtml:link
+        rel="alternate"
+        hreflang="{{ .Language.LanguageCode }}"
+        href="{{ .Permalink }}"
+        />{{ end }}
+  </url>
+    {{- end -}}
+  {{ end }}
+</urlset>


### PR DESCRIPTION
## What this does
Generates a sitemap.xml of all pages (excluding taxonomy and term pages)

## Why this is important
Having an up to date sitemap can assist Google in crawling and indexing new content faster. This will hopefully improve the sites search ranking.