### PR TITLE
Update domain in links to java docs

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -147,7 +147,7 @@ sections:
     languages:
       - logo: /images/language-logos/java.svg
         label: Java
-        link: https://testcontainers.org
+        link: https://java.testcontainers.org/
       - logo: /images/language-logos/go.svg
         label: Go
         link: https://golang.testcontainers.org/

--- a/content/getting-started/index.md
+++ b/content/getting-started/index.md
@@ -92,7 +92,7 @@ installing Docker locally. The following container runtime environments are offi
 * [Testcontainers Cloud](https://www.testcontainers.cloud/?utm_medium=direct&utm_source=testcontainers.com&utm_content=docs&utm_term=on-failure)
 
 For more extensive information on supported container runtime environments, as well as known limitations of 
-alternative container runtime environments, please refer to [this page](https://www.testcontainers.org/supported_docker_environment/).
+alternative container runtime environments, please refer to [this page](https://java.testcontainers.org/supported_docker_environment/).
 
 ## Testcontainers workflow
 You can use Testcontainers with any testing library you are already familiar with. 

--- a/content/modules/_example.md
+++ b/content/modules/_example.md
@@ -4,43 +4,36 @@ draft: true
 title: Name
 isOfficial: false
 categories:
-  - cloud-platform
-  - container-manager
-  - database
-  - event-streaming
-  - kv-store
+  - relational-database
+  - nosql-database
   - message-broker
-  - proxy
-  - search
-  - secret-store
-  - SSO
-  - storage
-  - web-driver
-  - web-server
+  - cloud
+  - web
+  - other
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/
+    url: https://java.testcontainers.org/modules/
     isThirdParty: false
     example: |
-      ```
+      ```java
       ```
   - id: go
     url: https://golang.testcontainers.org/modules/
     isThirdParty: false
     example: |
-      ```
+      ```go
       ```
   - id: dotnet
     url: https://dotnet.testcontainers.org/modules/
     isThirdParty: false
     example: |
-      ```
+      ```csharp
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/
     isThirdParty: false
     example: |
-      ```
+      ```javascript
       ```
 description: |
   What is this

--- a/content/modules/cassandra.md
+++ b/content/modules/cassandra.md
@@ -4,7 +4,7 @@ categories:
   - nosql-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/databases/cassandra/
+    url: https://java.testcontainers.org/modules/databases/cassandra/
     example: |
       ```java
       var cassandra = new CassandraContainer<>(DockerImageName.parse("cassandra:3.11.2"));

--- a/content/modules/clickhouse.md
+++ b/content/modules/clickhouse.md
@@ -4,7 +4,7 @@ categories:
   - relational-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/databases/clickhouse/
+    url: https://java.testcontainers.org/modules/databases/clickhouse/
     example: |
       ```java
       var clickHouseContainer = new ClickHouseContainer();

--- a/content/modules/cockroachdb.md
+++ b/content/modules/cockroachdb.md
@@ -5,7 +5,7 @@ categories:
   - relational-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/databases/cockroachdb/
+    url: https://java.testcontainers.org/modules/databases/cockroachdb/
     example: |
       ```java
       var cockroach = new new CockroachContainer(DockerImageName.parse("cockroachdb/cockroach:v22.2.3"));

--- a/content/modules/consul.md
+++ b/content/modules/consul.md
@@ -4,7 +4,7 @@ categories:
   - other
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/consul/
+    url: https://java.testcontainers.org/modules/consul/
     example: |
       ```java
       var consul = new ConsulContainer(DockerImageName.parse()"hashicorp/consul:1.15"));

--- a/content/modules/cosmosdb.md
+++ b/content/modules/cosmosdb.md
@@ -4,7 +4,7 @@ categories:
   - cloud
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/azure/
+    url: https://java.testcontainers.org/modules/azure/
     example: |
       ```java
       var cosmos = new CosmosDBEmulatorContainer(

--- a/content/modules/couchbase.md
+++ b/content/modules/couchbase.md
@@ -5,7 +5,7 @@ categories:
   - nosql-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/databases/couchbase/
+    url: https://java.testcontainers.org/modules/databases/couchbase/
     example: |
       ```java
       var couchbase = new CouchbaseContainer(DockerImageName.parse(

--- a/content/modules/db2.md
+++ b/content/modules/db2.md
@@ -4,7 +4,7 @@ categories:
   - relational-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/databases/db2/
+    url: https://java.testcontainers.org/modules/databases/db2/
     example: |
       ```java
       var db2 = new Db2Container(DockerImageName.parse("ibmcom/db2:11.5.0.0a"))

--- a/content/modules/dynalite.md
+++ b/content/modules/dynalite.md
@@ -4,7 +4,7 @@ categories:
   - nosql-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/databases/dynalite/
+    url: https://java.testcontainers.org/modules/databases/dynalite/
     example: |
       ```java
       var dynamoDB = new DynaliteContainer(DockerImageName.parse(

--- a/content/modules/elasticsearch.md
+++ b/content/modules/elasticsearch.md
@@ -4,7 +4,7 @@ categories:
   - nosql-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/elasticsearch/
+    url: https://java.testcontainers.org/modules/elasticsearch/
     example: |
       ```java
       var elastic = new ElasticsearchContainer(DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:7.9.2"));

--- a/content/modules/google-cloud.md
+++ b/content/modules/google-cloud.md
@@ -4,7 +4,7 @@ categories:
   - cloud
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/gcloud/
+    url: https://java.testcontainers.org/modules/gcloud/
     example: |
       ```java
       var bigtable = new BigtableEmulatorContainer(

--- a/content/modules/hivemq.md
+++ b/content/modules/hivemq.md
@@ -4,7 +4,7 @@ categories:
   - message-broker
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/hivemq/
+    url: https://java.testcontainers.org/modules/hivemq/
     example: |
       ```java
       var hivemqCe = new HiveMQContainer(DockerImageName.parse("hivemq/hivemq-ce")

--- a/content/modules/influxdb.md
+++ b/content/modules/influxdb.md
@@ -4,7 +4,7 @@ categories:
   - relational-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/databases/influxdb/
+    url: https://java.testcontainers.org/modules/databases/influxdb/
     example: |
       ```java
       var influx = new InfluxDBContainer<>(DockerImageName.parse("influxdb:2.0.7");

--- a/content/modules/k3s.md
+++ b/content/modules/k3s.md
@@ -4,7 +4,7 @@ categories:
   - other
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/k3s/
+    url: https://java.testcontainers.org/modules/k3s/
     example: |
       ```java
       var k3s = new K3sContainer(DockerImageName.parse("rancher/k3s:v1.21.3-k3s1"));

--- a/content/modules/kafka.md
+++ b/content/modules/kafka.md
@@ -4,7 +4,7 @@ categories:
   - message-broker
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/kafka/
+    url: https://java.testcontainers.org/modules/kafka/
     example: |
       ```java
       var kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.1"));

--- a/content/modules/localstack.md
+++ b/content/modules/localstack.md
@@ -5,7 +5,7 @@ categories:
   - cloud
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/localstack/
+    url: https://java.testcontainers.org/modules/localstack/
     example: |
       ```java
       var localstack = new LocalStackContainer(DockerImageName.parse("localstack/localstack:0.11.3"));

--- a/content/modules/mariadb.md
+++ b/content/modules/mariadb.md
@@ -4,7 +4,7 @@ categories:
   - relational-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/databases/mariadb/
+    url: https://java.testcontainers.org/modules/databases/mariadb/
     example: |
       ```java
       var mariaDB = new MariaDBContainer<>(DockerImageName.parse("mariadb:10.5.5"));

--- a/content/modules/mockserver.md
+++ b/content/modules/mockserver.md
@@ -4,7 +4,7 @@ categories:
   - web
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/mockserver/
+    url: https://java.testcontainers.org/modules/mockserver/
     example: |
       ```java
       var mockServer = new MockServerContainer(DockerImageName

--- a/content/modules/mongodb.md
+++ b/content/modules/mongodb.md
@@ -4,7 +4,7 @@ categories:
   - nosql-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/databases/mongodb/
+    url: https://java.testcontainers.org/modules/databases/mongodb/
     example: |
       ```java
       var mongoDBContainer = new MongoDBContainer(DockerImageName.parse("mongo:4.0.10"));

--- a/content/modules/mssql.md
+++ b/content/modules/mssql.md
@@ -4,7 +4,7 @@ categories:
   - relational-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/databases/mssqlserver/
+    url: https://java.testcontainers.org/modules/databases/mssqlserver/
     example: |
       ```java
       var mssqlserver = new MSSQLServerContainer()

--- a/content/modules/mysql.md
+++ b/content/modules/mysql.md
@@ -4,7 +4,7 @@ categories:
   - relational-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/databases/mysql/
+    url: https://java.testcontainers.org/modules/databases/mysql/
     example: |
       ```java
       var mysql = new MySQLContainer<>(DockerImageName.parse("mysql:5.7.34"));

--- a/content/modules/neo4j.md
+++ b/content/modules/neo4j.md
@@ -5,7 +5,7 @@ categories:
   - nosql-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/databases/neo4j/
+    url: https://java.testcontainers.org/modules/databases/neo4j/
     example: |
       ```java
       var neo4j = new Neo4jContainer<>(DockerImageName.parse("neo4j:4.4"));

--- a/content/modules/nginx.md
+++ b/content/modules/nginx.md
@@ -4,7 +4,7 @@ categories:
   - web
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/nginx/
+    url: https://java.testcontainers.org/modules/nginx/
     example: |
       ```java
       var nginx = new NginxContainer<>(DockerImageName.parse("nginx:1.23.4-alpine"));

--- a/content/modules/oracle-xe.md
+++ b/content/modules/oracle-xe.md
@@ -4,7 +4,7 @@ categories:
   - relational-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/databases/oraclexe/
+    url: https://java.testcontainers.org/modules/databases/oraclexe/
     example: |
       ```java
       var oracle = new OracleContainer(DockerImageName.parse("gvenzl/oracle-xe:21-slim-faststart"));

--- a/content/modules/orientdb.md
+++ b/content/modules/orientdb.md
@@ -4,7 +4,7 @@ categories:
   - nosql-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/databases/orientdb/
+    url: https://java.testcontainers.org/modules/databases/orientdb/
     example: |
       ```java
       var orient = new OrientDBContainer(DockerImageName.parse("orientdb:3.2.0-tp3"));

--- a/content/modules/postgresql.md
+++ b/content/modules/postgresql.md
@@ -4,7 +4,7 @@ categories:
   - relational-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/databases/postgres/
+    url: https://java.testcontainers.org/modules/databases/postgres/
     example: |
       ```java
       var postgres = new PostgreSQLContainer<>(DockerImageName.parse(("postgres:9.6.12"));

--- a/content/modules/presto.md
+++ b/content/modules/presto.md
@@ -4,7 +4,7 @@ categories:
   - relational-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/databases/presto/
+    url: https://java.testcontainers.org/modules/databases/presto/
     example: |
       ```java
       var presto = new PrestoContainer(DockerImageName.parse("ghcr.io/trinodb/presto:344"));

--- a/content/modules/pulsar.md
+++ b/content/modules/pulsar.md
@@ -5,7 +5,7 @@ categories:
   - message-broker
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/pulsar/
+    url: https://java.testcontainers.org/modules/pulsar/
     example: |
       ```java
       var pulsar = new PulsarContainer(DockerImageName.parse("apachepulsar/pulsar:2.10.0"));

--- a/content/modules/questdb.md
+++ b/content/modules/questdb.md
@@ -4,7 +4,7 @@ categories:
   - relational-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/databases/questdb/
+    url: https://java.testcontainers.org/modules/databases/questdb/
     example: |
       ```java
       var questdb = new QuestDBContainer(DockerImageName.parse("questdb/questdb:6.5.3"));

--- a/content/modules/rabbitmq.md
+++ b/content/modules/rabbitmq.md
@@ -4,7 +4,7 @@ categories:
   - message-broker
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/rabbitmq/
+    url: https://java.testcontainers.org/modules/rabbitmq/
     example: |
       ```java
       var rabbit = new RabbitMQContainer(DockerImageName.parse("rabbitmq:3.7.25-management-alpine"));

--- a/content/modules/redpanda.md
+++ b/content/modules/redpanda.md
@@ -5,7 +5,7 @@ categories:
   - message-broker
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/redpanda/
+    url: https://java.testcontainers.org/modules/redpanda/
     example: |
       ```java
       var redpanda = new RedpandaContainer(DockerImageName.parse("docker.redpanda.com/redpandadata/redpanda:v22.2.1"));

--- a/content/modules/selenium.md
+++ b/content/modules/selenium.md
@@ -4,7 +4,7 @@ categories:
   - web
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/webdriver_containers/
+    url: https://java.testcontainers.org/modules/webdriver_containers/
     example: |
       ```java
       var chrome = new BrowserWebDriverContainer<>()

--- a/content/modules/solace.md
+++ b/content/modules/solace.md
@@ -4,7 +4,7 @@ categories:
   - message-broker
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/solace/
+    url: https://java.testcontainers.org/modules/solace/
     isThirdParty: false
     example: |
       ```java

--- a/content/modules/solr.md
+++ b/content/modules/solr.md
@@ -4,7 +4,7 @@ categories:
   - nosql-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/solr/
+    url: https://java.testcontainers.org/modules/solr/
     example: |
       ```java
       var solr = new SolrContainer(DockerImageName.parse("solr:8.3.0"));

--- a/content/modules/sqledge.md
+++ b/content/modules/sqledge.md
@@ -4,7 +4,7 @@ categories:
   - cloud
 docs:
   - id: dotnet
-    url: https://www.testcontainers.org/modules/azure/
+    url: https://java.testcontainers.org/modules/azure/
     example: |
       ```csharp
       var sqlEdgeContainer = new SqlEdgeBuilder()

--- a/content/modules/tidb.md
+++ b/content/modules/tidb.md
@@ -4,7 +4,7 @@ categories:
   - relational-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/databases/tidb/
+    url: https://java.testcontainers.org/modules/databases/tidb/
     example: |
       ```java
       var tidb = new TiDBContainer(DockerImageName.parse("pingcap/tidb:v6.1.0"));

--- a/content/modules/toxiproxy.md
+++ b/content/modules/toxiproxy.md
@@ -4,7 +4,7 @@ categories:
   - web
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/toxiproxy/
+    url: https://java.testcontainers.org/modules/toxiproxy/
     example: |
       ```java
       var toxiproxy = new ToxiproxyContainer(DockerImageName.parse(("ghcr.io/shopify/toxiproxy:2.5.0"));

--- a/content/modules/trino.md
+++ b/content/modules/trino.md
@@ -4,7 +4,7 @@ categories:
   - relational-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/databases/trino/
+    url: https://java.testcontainers.org/modules/databases/trino/
     example: |
       ```java
       var trino = new TrinoContainer(DockerImageName.parse("trinodb/trino:352"));

--- a/content/modules/vault.md
+++ b/content/modules/vault.md
@@ -4,7 +4,7 @@ categories:
   - other
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/vault/
+    url: https://java.testcontainers.org/modules/vault/
     example: |
       ```java
       var vault = new VaultContainer<>(DockerImageName.parse(("hashicorp/vault:1.13.0"));

--- a/content/modules/yugabytedb.md
+++ b/content/modules/yugabytedb.md
@@ -5,7 +5,7 @@ categories:
   - relational-database
 docs:
   - id: java
-    url: https://www.testcontainers.org/modules/databases/yugabytedb/
+    url: https://java.testcontainers.org/modules/databases/yugabytedb/
     isThirdParty: false
     example: |
       ```java

--- a/data/languages.yml
+++ b/data/languages.yml
@@ -1,7 +1,7 @@
 - id: java
   label: Java
   logo: /images/language-logos/java.svg
-  link: https://testcontainers.org
+  link: https://java.testcontainers.org/
 - id: go
   label: Go
   logo: /images/language-logos/go.svg


### PR DESCRIPTION
## What this does
Updates any links to the java docs site from `testcontainers.org`/`www.testcontainers.org` to `java.testcontainers.org`

## Why this is important
We are migrating the java docs to this subdomain and adding redirects from the testcontainers.org root domain index page to testcontainers.com. To ensure people who are redirected can still access the java docs these links need to point to the correct domain.  