### PR TITLE
Move pricing page under cloud and add redirect

### DIFF
--- a/content/cloud/pricing.md
+++ b/content/cloud/pricing.md
@@ -1,5 +1,5 @@
 ---
-title: Pricing
+title: Testcontainers Cloud Pricing
 submenu: cloud
 sections:
   - partial: pricing

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -24,22 +24,22 @@
     <nav>
         <ul class="menu">
             <li class="menu-item">
-                <a href="/cloud">
+                <a href="/cloud/">
                     Cloud
                 </a>
             </li>
             <li class="menu-item">
-                <a href="/getting-started">
+                <a href="/getting-started/">
                     Getting Started
                 </a>
             </li>
             <li class="menu-item">
-                <a href="/guides">
+                <a href="/guides/">
                     Guides
                 </a>
             </li>
             <li class="menu-item">
-                <a href="/modules">
+                <a href="/modules/">
                     Modules
                 </a>
             </li>
@@ -71,7 +71,7 @@
                 </a>
             </li>
             <li class="menu-item">
-                <a href="https://github.com/testcontainers" target="_blank">
+                <a href="https://github.com/testcontainers/" target="_blank">
                     {{ partial "svgs/github" }}
                     <span class="sr-only">GitHub</span>
                 </a>
@@ -82,7 +82,7 @@
 {{ define "subheader" }}
     {{ if eq .Params.submenu "cloud" }}
     <div id="subheader">
-        <a class="subheader-title" href="/cloud">Testcontainers Cloud</a>
+        <a class="subheader-title" href="/cloud/">Testcontainers Cloud</a>
         <button id="mobile-submenu-toggle">
             <span class="sr-only">Subheader Menu</span>
             <svg width="30" height="30" viewBox="0 0 30 30" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
@@ -94,17 +94,17 @@
         <nav>
             <ul class="subheader-menu">
                 <li class="menu-item">
-                    <a href="/cloud/desktop">
+                    <a href="/cloud/desktop/">
                         On Desktop
                     </a>
                 </li>
                 <li class="menu-item">
-                    <a href="/cloud/ci">
+                    <a href="/cloud/ci/">
                         On CI
                     </a>
                 </li>
                 <li class="menu-item">
-                    <a href="/pricing">
+                    <a href="/cloud/pricing/">
                         Pricing
                     </a>
                 </li>

--- a/netlify.toml
+++ b/netlify.toml
@@ -29,3 +29,8 @@
     from = "/guides/guide/*"
     to = "/guides/:splat"
     status = 301
+
+[[redirects]]
+    from = "/pricing"
+    to = "/cloud/pricing/"
+    status = 301


### PR DESCRIPTION
## What this does
Moves the `/pricing/` page to `/cloud/pricing/` and adds a netlify redirect from the old location to the new one. Additionally updates other links in the subheader to have trailing slashes to reduce redirects from no slash to trailing slashed (seo) 

## Why this is important 
The current pricing page location implies that the page is pricing for testcontainers in general. Moving it into the cloud subdirectory clarifies that the pricing is relevant to the cloud product.   