### PR TITLE
Add getting started links to code examples section

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -66,6 +66,15 @@ allTabLabels.forEach((label) => {
                 panel.classList.remove("active");
             }
         });
+
+        const gettingStartedButtons = e.target.closest(".code-examples").querySelectorAll(".getting-started-button");
+        gettingStartedButtons.forEach((button) => {
+            if (button.dataset.id === targetId) {
+                button.classList.add("active");
+            } else {
+                button.classList.remove("active");
+            }
+        });
     });
 });
 

--- a/assets/sass/sections/_code-examples.scss
+++ b/assets/sass/sections/_code-examples.scss
@@ -19,6 +19,79 @@
         }
     }
 
+    .getting-started-links {
+        padding-top: 15px;
+    }
+
+    .button  {
+        display: none;
+        width: max-content;
+        max-width: 100%;
+
+        &:hover {
+            background: none;
+            color: $topaz;
+        }
+
+        &.active {
+            display: flex;
+        }
+    }
+
+    .getting-started-button {
+        display: none;
+        width: max-content;
+        max-width: 100%;
+        align-items: center;
+        gap: 10px;
+        border: 1px solid $mist;
+        border-radius: 6px;
+        padding: 10px;
+        text-decoration: none;
+        color: $eggplant;
+        font-weight: 500;
+        transition: 
+            color 0.2s ease,
+            background 0.2s ease;
+
+        @media (min-width: 650px) {  
+            padding: 20px 30px;
+        }
+
+        .icon-caret {
+            transform: rotate(-90deg);
+            height: rem(10px);
+            flex-shrink: 0;
+            color: $fog;
+            margin-left: auto;
+        }
+
+        .icon-external {
+            height: rem(10px);
+            flex-shrink: 0;
+            color: $fog;
+            margin-left: auto;
+
+            @media (min-width: 600px) {
+                height: rem(15px);
+            }
+        } 
+
+        &:hover {
+            color: $topaz;
+            background: rgba($catskill, 0.45);
+
+            .icon-external,
+            .icon-caret {
+                color: $topaz;
+            }
+        }
+
+        &.active {
+            display: flex;
+        }
+    }
+
     .examples {
         width: 100%;
         display: flex;

--- a/assets/sass/sections/_logo-wall.scss
+++ b/assets/sass/sections/_logo-wall.scss
@@ -53,4 +53,54 @@
         gap: 20px;
         justify-content: center;
     }
+
+    .logo-wall-button {
+        display: flex;
+        width: max-content;
+        max-width: 100%;
+        align-items: center;
+        gap: 10px;
+        border: 1px solid $mist;
+        border-radius: 6px;
+        padding: 10px;
+        text-decoration: none;
+        color: $eggplant;
+        font-weight: 500;
+        transition: 
+            color 0.2s ease,
+            background 0.2s ease;
+
+        @media (min-width: 650px) {  
+            padding: 20px 30px;
+        }
+
+        .icon-caret {
+            transform: rotate(-90deg);
+            height: rem(10px);
+            flex-shrink: 0;
+            color: $fog;
+            margin-left: auto;
+        }
+
+        .icon-external {
+            height: rem(10px);
+            flex-shrink: 0;
+            color: $fog;
+            margin-left: auto;
+
+            @media (min-width: 600px) {
+                height: rem(15px);
+            }
+        } 
+
+        &:hover {
+            color: $topaz;
+            background: rgba($catskill, 0.45);
+
+            .icon-external,
+            .icon-caret {
+                color: $topaz;
+            }
+        }
+    }
 }

--- a/content/_index.md
+++ b/content/_index.md
@@ -14,6 +14,8 @@ sections:
     examples:
       - id: java
         label: Java
+        url: /guides/getting-started-with-testcontainers-for-java/
+        external: false
         icon: /images/language-logos/java.svg
         code: |
           ```java
@@ -22,6 +24,8 @@ sections:
           ```
       - id: go
         label: Go
+        url: /guides/getting-started-with-testcontainers-for-go/
+        external: false
         icon: /images/language-logos/go.svg
         code: |
           ```go
@@ -36,6 +40,8 @@ sections:
           ```
       - id: dotnet
         label: .NET
+        url: /guides/getting-started-with-testcontainers-for-dotnet/
+        external: false
         icon: /images/language-logos/dotnet.svg
         code: |
           ```csharp
@@ -44,6 +50,8 @@ sections:
           ```
       - id: nodejs
         label: Node.js
+        url: /guides/getting-started-with-testcontainers-for-nodejs/
+        external: false
         icon: /images/language-logos/nodejs.svg
         code: |
           ```javascript
@@ -54,6 +62,8 @@ sections:
           ```
       - id: python
         label: Python
+        url: https://testcontainers-python.readthedocs.io/en/latest/
+        external: true
         icon: /images/language-logos/python.svg
         code: |
           ```python
@@ -66,6 +76,8 @@ sections:
           ```
       - id: rust
         label: Rust
+        url: https://docs.rs/testcontainers/latest/testcontainers/
+        external: true
         icon: /images/language-logos/rust.svg
         code: |
           ```rust
@@ -74,6 +86,8 @@ sections:
           ```
       - id: haskell
         label: Haskell
+        url: https://github.com/testcontainers/testcontainers-hs
+        external: true
         icon: /images/language-logos/haskell.svg
         code: |
           ```haskell
@@ -85,6 +99,8 @@ sections:
           ```
       - id: ruby
         label: Ruby
+        url: https://github.com/testcontainers/testcontainers-ruby
+        external: true
         icon: /images/language-logos/ruby.svg
         code: |
           ```ruby

--- a/layouts/partials/sections/code-examples.html
+++ b/layouts/partials/sections/code-examples.html
@@ -4,6 +4,29 @@
             <div class="small-header gradient">{{ .section.small_title }}</div>
             <h2>{{ .section.title }}</h2>
             <div>{{ .section.description | markdownify }}</div>
+            <div class="getting-started-links">
+                {{ range $index, $example := .section.examples }}
+                    {{ $buttonClasses := "getting-started-button" }}
+                    {{ if eq $index 0 }}
+                       {{ $buttonClasses = print $buttonClasses " active" }}
+                    {{ end }}
+                    <a class="{{ $buttonClasses }}" data-id="{{ $example.id }}" href="{{ $example.url }}" {{ if $example.external }}target="_bank"{{ end }}>
+                        {{ if $example.icon }}
+                            {{ partial "img.html" (dict "image" (resources.Get $example.icon) "alt" "") }}
+                        {{ end }}
+                        Get started with {{ $example.label }}
+                        {{ if $example.external }}
+                            <svg class="icon-external" width="15" height="17" viewBox="0 0 15 17">
+                                <use href="#icon-external"></use>
+                            </svg>
+                        {{ else }}
+                            <svg class="icon-caret" height="10" viewBox="0 0 10 10">
+                                <use href="#icon-caret"></use>
+                            </svg>
+                        {{ end }}
+                    </a>
+                {{ end }}
+            </div>
         </div>
         <div class="examples">
             <div class="tab-labels">

--- a/layouts/partials/sections/logo-wall.html
+++ b/layouts/partials/sections/logo-wall.html
@@ -11,11 +11,16 @@
         </div>
         <div class="buttons">
             {{ range .section.buttons }}
-                {{ $buttonClasses := slice "button" }}
+                {{ $buttonClasses := slice "logo-wall-button" }}
                 {{ with .style }}
                     {{ $buttonClasses = $buttonClasses | append . }}
                 {{ end }}
-                <a class='{{ delimit $buttonClasses " " }}' href="{{ .url }}" target="{{ .target }}">{{ .label }}</a>
+                <a class='{{ delimit $buttonClasses " " }}' href="{{ .url }}" target="{{ .target }}">
+                    {{ .label }}
+                    <svg class="icon-caret" height="10" viewBox="0 0 10 10">
+                        <use href="#icon-caret"></use>
+                    </svg>
+                </a>
             {{ end }}
         </div>
     </div>


### PR DESCRIPTION
## What this does
Adds links to the relevant getting started guide (or external documentation) based on the currently selected language in the code examples section.

Before:
![image](https://github.com/testcontainers/testcontainers-site/assets/6667679/f6f54fbe-47f2-4392-bcdb-d2ba9dca83bf)

After:
![image](https://github.com/testcontainers/testcontainers-site/assets/6667679/4208a1da-e077-47d1-93cb-c35a457afb53)

## Why this is important
Visitors who want to jump right into practical application of the library currently have to search through the content of the site to find how to get started. These links surface the valuable guides content on the front page and give those visitors a clear path forward.  