### PR TITLE
Fixed macos apple download link

### DIFF
--- a/layouts/partials/sections/download-banner.html
+++ b/layouts/partials/sections/download-banner.html
@@ -1,8 +1,8 @@
-{{- $downloadLinkMacIntel := "https://app.testcontainers.cloud/download/testcontainers-cloud-desktop_darwin_x86-64.dmg" -}}
-{{- $downloadLinkMacApple := "https://app.testcontainers.cloud/download/testcontainers-cloud-desktop_darwin_arm64.dmg" -}}
-{{- $downloadLinkWindows := "https://app.testcontainers.cloud/download/testcontainers-cloud-desktop_windows_x86-64.msi" -}}
-{{- $downloadLinkLinuxDeb := "https://app.testcontainers.cloud/download/testcontainers-cloud-desktop_linux_x86-64.deb" -}}
-{{- $downloadLinkLinuxRpm := "https://app.testcontainers.cloud/download/testcontainers-cloud-desktop_linux_x86-64.rpm" -}}
+{{- $downloadLinkMacIntel := "https://app.testcontainers.cloud/download/testcontainers-desktop_darwin_x86-64.dmg" -}}
+{{- $downloadLinkMacApple := "https://app.testcontainers.cloud/download/testcontainers-desktop_darwin_arm64.dmg" -}}
+{{- $downloadLinkWindows := "https://app.testcontainers.cloud/download/testcontainers-desktop_windows_x86-64.msi" -}}
+{{- $downloadLinkLinuxDeb := "https://app.testcontainers.cloud/download/testcontainers-desktop_linux_x86-64.deb" -}}
+{{- $downloadLinkLinuxRpm := "https://app.testcontainers.cloud/download/testcontainers-desktop_linux_x86-64.rpm" -}}
 <section class="download-banner active-macos">
     <div class="container">
         <div class="content">


### PR DESCRIPTION
## What this does
Fixes the macos apple silicon desktop download link using the intel file link 

## Why it is important
Apple silicon users should feel like they are downloading a files intended for them.

part of https://github.com/AtomicJar/testcontainers-cloud-client/issues/585