### PR TITLE
Remove cloud from desktop brew install command

### DIFF
--- a/layouts/partials/sections/download-banner.html
+++ b/layouts/partials/sections/download-banner.html
@@ -14,7 +14,7 @@
                 <div class="instructions">{{ . }}</div>
             {{ end }}
             <div class="download-section macos">
-                <pre><code class="language-shell" data-lang="shell">$ brew install atomicjar/tap/testcontainers-cloud-desktop</code></pre>
+                <pre><code class="language-shell" data-lang="shell">$ brew install atomicjar/tap/testcontainers-desktop</code></pre>
                 <div class="buttons">
                     <a class="button has-extra" href="{{- $downloadLinkMacIntel -}}">
                         <span>Download for Mac</span>


### PR DESCRIPTION
## What this does
Changes the brew install command from `testcontainers-cloud-desktop` to  `testcontainers-desktop`

## Why it is important
We will be renaming the cask soon