### PR TITLE
Fix brew desktop install copy

### DIFF
--- a/layouts/partials/sections/download-banner.html
+++ b/layouts/partials/sections/download-banner.html
@@ -14,7 +14,7 @@
                 <div class="instructions">{{ . }}</div>
             {{ end }}
             <div class="download-section macos">
-                <pre><code class="language-shell" data-lang="shell">$ brew install atomicjar/tap/testcontainers-desktop</code></pre>
+                <pre><code class="language-shell" data-lang="shell">brew install atomicjar/tap/testcontainers-desktop</code></pre>
                 <div class="buttons">
                     <a class="button has-extra" href="{{- $downloadLinkMacIntel -}}">
                         <span>Download for Mac</span>


### PR DESCRIPTION
## What this does
Removes `$` from the start of the desktop brew install command

## Why is is important
Copying the code snippet as is includes the `$` and cannot be pasted into a terminal without editing it