### PR TITLE
Add optional extra content to modules pages

### DIFF
--- a/assets/sass/_longform.scss
+++ b/assets/sass/_longform.scss
@@ -26,9 +26,14 @@
         }
     }
 
-    .container > .content {
+    .container > .content,
+    .section.content {
         flex: 1 1 auto;
-        font-size: rem(18px);
+        font-size: rem(16px);
+
+        @media (min-width: 1024px) {
+            font-size: rem(18px);
+        }
 
         & > *:first-child {
             margin-top: 0;

--- a/assets/sass/modules/_module-content.scss
+++ b/assets/sass/modules/_module-content.scss
@@ -95,6 +95,11 @@
         flex-direction: column;
         gap: 40px;
         overflow: hidden;
+        font-size: rem(16px);
+
+        @media (min-width: 1024px) {
+            font-size: rem(18px);
+        }
 
         h2 {
             margin-bottom: 10px;
@@ -162,19 +167,55 @@
             overflow: hidden;
             margin: 0;
             border-radius: 6px;
+
+            > code {
+                display: block;
+                overflow-x: auto;
+                font-family: "Roboto Mono", 'Courier New', Courier, monospace;
+                background: $plum;
+                color: $catskill;
+                padding: 20px;
+                border-radius: 6px;
+        
+                @media (min-width: 500px) {
+                    padding: 40px;
+                }
+            }
         }
-    
-        code {
-            display: block;
-            overflow-x: auto;
-            font-family: "Roboto Mono", 'Courier New', Courier, monospace;
-            background: $plum;
-            color: $catskill;
-            padding: 20px;
-            border-radius: 6px;
-    
-            @media (min-width: 500px) {
-                padding: 40px;
+
+        .section.content {
+            h1 {
+                color: $eggplant;
+                font-size: rem(24px);
+                font-weight: 700;
+                line-height: 1.1;
+            
+                @media (min-width: 780px) {
+                    font-size: rem(48px);
+                } 
+            }
+            
+            h2 {
+                color: $eggplant;
+                font-size: rem(20px);
+                font-weight: 500;
+                margin: 0;
+            
+                @media (min-width: 780px) {
+                    font-size: rem(24px);
+                } 
+            }
+            
+            h3 {
+                color: $eggplant;
+                font-size: rem(18px);
+                font-weight: 500;
+                margin: 0;
+            
+                @media (min-width: 780px) {
+                    font-size: rem(20px);
+                
+                }
             }
         }
     }

--- a/layouts/modules/single.html
+++ b/layouts/modules/single.html
@@ -64,7 +64,7 @@
           </div>
         </div>
       </header>
-      <div class="module-content">
+      <div class="module-content longform-content">
         <div class="container">
             <div class="sidebar">
               <div>
@@ -148,6 +148,11 @@
                       {{ end }}
                     </div>
                   </div>
+                </div>
+              {{ end }}
+              {{ with .Content }}
+                <div class="section content">
+                  {{ . }}
                 </div>
               {{ end }}
           </div>


### PR DESCRIPTION
## What this does
Adds the option to include arbitrary markdown content below the example code blocks on module pages.

## Why it is important
We want to be able to include more content on these pages such as tips for how to use the modules and links to useful articles and resources.