### PR TITLE
Remove july cloud discount

### DIFF
--- a/content/cloud/pricing.md
+++ b/content/cloud/pricing.md
@@ -54,10 +54,8 @@ sections:
         prices:
           - label: / Seat per Month (on Desktop)
             value: $35
-            discountValue: $17.50
           - label: / Worker Minute (in the CI)
             value: $0.02
-            discountValue: $0.01
         features:
           - value: |
               Yes


### PR DESCRIPTION
# Remove July cloud discount

[🔗 CLOUD-141](https://atomicjar.atlassian.net/browse/CLOUD-141)

## Context
The early adopter discount is meant to expire at the end of July.

![image](https://github.com/testcontainers/testcontainers-site/assets/1202463/4842d9ec-48ff-42ec-aad6-75432c2690f6)

## Changes
- [x] Update the public pricing page removing the July discount

## Screenshots
<img width="1434" alt="Captura de pantalla 2023-08-02 a las 9 54 16" src="https://github.com/testcontainers/testcontainers-site/assets/1202463/08a95619-bcb9-409d-96a9-fa315d8a3153">
