### PR TITLE
Remove early adopter discount

### DIFF
--- a/content/cloud/pricing.md
+++ b/content/cloud/pricing.md
@@ -54,14 +54,13 @@ sections:
         prices:
           - label: / Seat per Month (on Desktop)
             value: $35
-            discountValue: $17.50
+            discountValue:
           - label: / Worker Minute (in the CI)
             value: $0.02
-            discountValue: $0.01
-        discount:
-          title: Early Adopter Pricing!
-          description: |
-            Discount ends in July 2023: subscribe now to lock it in.
+            discountValue:
+#        discount:
+#          title:
+#          description:
         features:
           - value: |
               Yes


### PR DESCRIPTION
## What this does
Removes the early adopter discount pricing from the cloud pricing page.

## Why this is important
The discount period has ended.