### PR TITLE
Allow modules filter to be set by url parameters

### DIFF
--- a/assets/js/modules.js
+++ b/assets/js/modules.js
@@ -53,7 +53,7 @@ function showFilterResults(replaceState = true) {
 
     if (replaceState) {
         const url = new URL(location);
-        //updateUrlFilter(url, 's', search.value); // Causes too many history states for now.
+        updateUrlFilter(url, 's', search.value);
         updateUrlFilter(url, 'official', officialFilter);
         updateUrlFilter(url, 'language', languageFilter[0]);
         updateUrlFilter(url, 'category', categoryFilter[0]);


### PR DESCRIPTION
## What this does
Updates the modules filter to include url parameter support.

e.g:
https://deploy-preview-103--testcontainers-site.netlify.app/modules/?official=true
https://deploy-preview-103--testcontainers-site.netlify.app/modules/?official=true&language=go
https://deploy-preview-103--testcontainers-site.netlify.app/modules/?official=true&language=go&category=message-broker
https://deploy-preview-103--testcontainers-site.netlify.app/modules/?official=true&language=go&category=message-broker&s=redpan

## Why this is important
This will allow for pre-filtering the modules list to only the relevant modules in links.