### PR TITLE
feat: add mariadb Go module

### DIFF
--- a/content/modules/mariadb.md
+++ b/content/modules/mariadb.md
@@ -10,6 +10,12 @@ docs:
       var mariaDB = new MariaDBContainer<>(DockerImageName.parse("mariadb:10.5.5"));
       mariaDB.start();
       ```
+  - id: go
+    url: https://golang.testcontainers.org/modules/mariadb
+    example: |
+      ```go
+      container, err := mariadb.RunContainer(ctx, testcontainers.WithImage("mariadb:11.0.3"))
+      ```
   - id: dotnet
     url: https://www.nuget.org/packages/Testcontainers.MariaDb
     example: |


### PR DESCRIPTION
## What does this PR do?
It adds MariaDB code example

## How to test this?

Render URL: https://deploy-preview-114--testcontainers-site.netlify.app/modules/mariadb/

Locally:
```shell
./dev.sh
hugo server
open http://localhost:1313/modules/mariadb/
```


