### PR TITLE
Add mixpanel install attribution script

### DIFF
--- a/content/event-data.md
+++ b/content/event-data.md
@@ -1,0 +1,4 @@
+---
+type: attribution
+sitemap_exclude: true
+---

--- a/layouts/attribution/baseof.html
+++ b/layouts/attribution/baseof.html
@@ -1,0 +1,79 @@
+{{- $mixpanelToken := "0897a75fb0160b842eb1218bad4fe322" -}}
+{{- if hugo.IsProduction -}}
+{{- $mixpanelToken = "77dfea682129533729f4dbcd188952e5" -}}
+{{- end -}}
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="robots" content="noindex, nofollow">
+        <script type="text/javascript">
+            const MIXPANEL_CUSTOM_LIB_URL = "https://telemetry.services.testcontainers.cloud/lib.min.js";
+            (function(f,b){if(!b.__SV){var e,g,i,h;window.mixpanel=b;b._i=[];b.init=function(e,f,c){function g(a,d){var b=d.split(".");2==b.length&&(a=a[b[0]],d=b[1]);a[d]=function(){a.push([d].concat(Array.prototype.slice.call(arguments,0)))}}var a=b;"undefined"!==typeof c?a=b[c]=[]:c="mixpanel";a.people=a.people||[];a.toString=function(a){var d="mixpanel";"mixpanel"!==c&&(d+="."+c);a||(d+=" (stub)");return d};a.people.toString=function(){return a.toString(1)+".people (stub)"};i="disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking start_batch_senders people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(" ");
+            for(h=0;h<i.length;h++)g(a,i[h]);var j="set set_once union unset remove delete".split(" ");a.get_group=function(){function b(c){d[c]=function(){call2_args=arguments;call2=[c].concat(Array.prototype.slice.call(call2_args,0));a.push([e,call2])}}for(var d={},e=["get_group"].concat(Array.prototype.slice.call(arguments,0)),c=0;c<j.length;c++)b(j[c]);return d};b._i.push([e,f,c])};b.__SV=1.2;e=f.createElement("script");e.type="text/javascript";e.async=!0;e.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===f.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";g=f.getElementsByTagName("script")[0];g.parentNode.insertBefore(e,g)}})(document,window.mixpanel||[]);
+        </script>    
+    </head>
+    <body>
+        <script>
+            const searchParams = new URLSearchParams(window.location.search);
+            if(searchParams.has('id')){ 
+                const utms = [];
+
+                const referrerCookie = getCookie("__gtm_referrer");
+                if (referrerCookie) {
+                    utms.push({
+                        key: "original_referrer",
+                        value: referrerCookie
+                    });
+                }
+
+                const campaignCookie = getCookie("__gtm_campaign_url");
+                if (campaignCookie) {
+                    const url = new URL(campaignCookie);
+                    const params = new URLSearchParams(url.search);
+                    const cookieUtms = parseUtms(params);
+                    utms.push(...cookieUtms);
+                }
+
+                function getCookie(key) {
+                    var cookies = document.cookie.split(";");
+                    for(var i = 0; i < cookies.length; i++) {
+                        var cookie = cookies[i].split("=");
+                        if(key == cookie[0].trim()) {
+                            return decodeURIComponent(cookie[1]);
+                        }
+                    }
+                    return null;
+                }
+
+                function parseUtms(params) {
+                    const utms = [];
+                    const utmKeys = [
+                        "utm_campaign",
+                        "utm_source",
+                        "utm_medium",
+                        "utm_term",
+                        "utm_content"
+                    ];
+                    utmKeys.forEach((key) => {
+                        const value = params.get(key) || false;
+                        if (value) utms.push({
+                            key: key,
+                            value: value
+                        });
+                    });
+                    return utms;
+                }
+
+                mixpanel.init("{{- $mixpanelToken -}}", {
+                    track_pageview: false,
+                    api_host: "https://telemetry.services.testcontainers.cloud",
+                    disable_persistence: true
+                });
+                mixpanel.track('attribution', {
+                    'installation_id':searchParams.get('id'),
+                    'attribution': utms
+                });
+            }
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
## What this does
Adds a page to be used by `testcontainers-cloud-web` that submits a mixpanel event with the provided installation_id and any attribution UTMs the user has. See [CLOUD-233](https://atomicjar.atlassian.net/browse/CLOUD-233)

## Why this is important 
We lose all marketing attribution data when users download and sign up from the desktop app at the moment, this should help fix that. 