### PR TITLE
feat: add kafka-kraft module

### DIFF
--- a/content/modules/kafka.md
+++ b/content/modules/kafka.md
@@ -10,6 +10,12 @@ docs:
       var kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.1"));
       kafka.start();
       ```
+  - id: go
+    url: https://golang.testcontainers.org/modules/kafka/
+    example: |
+      ```go
+      kafkaContainer, err := kafka.RunContainer(ctx, testcontainers.WithImage("confluentinc/confluent-local:7.5.0"))
+      ```
   - id: dotnet
     url: https://www.nuget.org/packages/Testcontainers.Kafka
     example: |


### PR DESCRIPTION
## What does this PR do?
It adds Kafka + KRaft Go module to the modules catalog

Render URL: https://deploy-preview-120--testcontainers-site.netlify.app/modules/kafka/