### PR TITLE
Add link to blog to header

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -71,6 +71,14 @@
                 </ul>
             </li>
             <li class="menu-item">
+                <a href="https://atomicjar.com/category/testcontainers/">
+                    <span>Blog</span>
+                    <svg class="icon-external" width="15" height="17" viewBox="0 0 15 17">
+                        <use href="#icon-external"></use>
+                    </svg>
+                </a>
+            </li>
+            <li class="menu-item">
                 <a href="https://slack.testcontainers.org/" target="_blank">
                     {{ partial "svgs/slack" }}
                     <span class="sr-only">Slack</span>


### PR DESCRIPTION
## What this does
Adds a link to the `testcontainers` category on the `atomicjar.com` blog to the main header

## Why this is important
At the moment we are publishing most of our updates on the atomicjar blog but don't have an good way for users to organically discover these other than our twitter posts.