### PR TITLE
Update pricing from trial to free plan

### DIFF
--- a/content/cloud/pricing.md
+++ b/content/cloud/pricing.md
@@ -48,7 +48,7 @@ sections:
             checkmark: false
           - value: 1
             checkmark: false
-      - title: Team (beta)
+      - title: Team
         description: The full power of Testcontainers Cloud for teams, on Desktop and in your CI.
         prices:
           - label: / Seat per Month (on Desktop)


### PR DESCRIPTION
## What this does
Updates the pricing page plans to change the `trial` plant to the `free` plan which includes the 300 minutes cloud quota.  

## Why it is important
When we enable the free plan quota the pricing displayed on the website and web app need to be in sync. 