### PR TITLE
Fix module header extra top padding

### DIFF
--- a/assets/sass/modules/_module-header.scss
+++ b/assets/sass/modules/_module-header.scss
@@ -1,8 +1,8 @@
 .module-header {
-    padding: 70px 0 20px 0;
+    padding: 0 0 20px 0;
 
     @media (min-width: 680px) {
-        padding: 88px 0 40px 0;
+        padding: 0 0 40px 0;
     }
 
     .container {


### PR DESCRIPTION
## What this does
Removes extra padding above the header on individual module pages