### PR TITLE
Add a desktop guide banner to desktop page

### DIFF
--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -176,6 +176,7 @@ a {
 @import "sections/download-banner";
 @import "sections/expereince-columns";
 @import "sections/featured-champions.scss";
+@import "sections/guide-callout.scss";
 @import "sections/hero-banner";
 @import "sections/icon-columns";
 @import "sections/logo-wall";

--- a/assets/sass/sections/_guide-callout.scss
+++ b/assets/sass/sections/_guide-callout.scss
@@ -1,0 +1,109 @@
+.guide-callout {
+    padding: 40px 20px;
+
+    @media (min-width: 780px) {
+        padding: 60px 20px;
+    }
+
+    .container {
+        display: grid;
+        align-items: center;
+        gap: 32px;
+        background-color: $ghost;
+        border-radius: 20px;
+        padding: 20px;
+
+        @media (min-width: 860px) {
+            grid-template-columns: repeat(2, 1fr);
+        }
+    }
+
+    .content {
+        display: flex;
+        flex-direction: column;
+        gap: 30px;
+        padding: 0 20px;
+
+        @media (max-width: 859px) {
+            text-align: center;
+        }
+
+        h2 {
+            @media (min-width: 860px) {
+                font-size: rem(36px);
+            }
+        }
+        
+        .description {
+            font-size: rem(14px);
+
+            @media (min-width: 860px) {
+                font-size: rem(18px);
+            }
+        }
+
+        .buttons {
+            display: flex;
+            
+            @media (max-width: 859px) {
+                justify-content: center;
+            }
+        }
+    }
+
+    .guides-list-item {
+        border: 1px solid $mist;
+        border-radius: 6px;
+        padding: 20px;
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+        text-decoration: none;
+        color: inherit;
+        transition: background-color 0.2s ease;
+        background: #fff;
+
+        &:hover {
+            background: rgba(#fff, 0.6);
+
+            h2 {
+                color: $topaz;
+            }
+        }
+
+        h2 {
+            line-height: 1.3;
+            transition: color 0.2s ease,;
+        }
+
+        .description {
+        }
+
+        .tag-list {
+            margin-top: auto;
+        }
+    }
+
+    .tag-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+    
+        .tag {
+            padding: 5px 10px;
+            font-size: rem(10px);
+            border-radius: 1000px;
+            transition: background-color 0.2s ease;
+            color: $eggplant;
+            background: $catskill;
+    
+            @media (min-width: 1600px) {
+                font-size: rem(12px);
+            }
+        }
+    }
+    
+    .guides-list-item:hover .tag {
+        background: $mist;
+    }
+}

--- a/content/desktop.md
+++ b/content/desktop.md
@@ -26,4 +26,8 @@ sections:
     description: |
       Want to give Podman or Rancher a try? Simply switch your local runtime for all your Testcontainers-powered dependencies. And with [Testcontainers Cloud](/cloud/), you can even run them in the cloud on demand, while saving your local resources.
     image: /images/desktop-cloud-illustration.png
+  - partial: guide-callout
+    title: Ready to get started?
+    description: This guide will walk you through the features of Testcontainers Desktop.
+    guide: guides/simple-local-development-with-testcontainers-desktop
 ---

--- a/layouts/partials/sections/guide-callout.html
+++ b/layouts/partials/sections/guide-callout.html
@@ -1,0 +1,34 @@
+{{ $title := .section.title }}
+{{ $description := .section.description }}
+{{ $guide := site.GetPage .section.guide }}
+<section class="guide-callout">
+    <div class="container">
+        <div class="content">
+            <h2>{{ $title | markdownify }}</h2>
+            <div class="description">{{ $description | markdownify }}</div>
+            <div class="buttons">
+                <a class="button" href="{{ $guide.RelPermalink }}">Read the Guide</a>
+            </div>
+        </div>
+        <div class="guide">
+            {{ with $guide }}
+                <a href="{{ .RelPermalink }}" class="guides-list-item">       
+                    <h2>{{ .Title }}</h2>
+                    {{ if .Description }}
+                    <div class="description">{{ .Description }}</div>
+                    {{ end }}
+                    {{ if or (.GetTerms "languages") (.GetTerms "tags") }}
+                    <ul class="tag-list">
+                        {{ range (.GetTerms "languages") }}
+                            <li class="tag language">{{ .Title }}</li>
+                        {{ end }}
+                        {{ range (.GetTerms "tags") }}
+                            <li class="tag">{{ .Title }}</li>
+                        {{ end }}
+                    </ul>
+                    {{ end }}
+                </a>
+            {{ end }}
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
## What this does
Adds a banner to the bottom of `/desktop/` that links to the Testcontainers Desktop guide

## Why this is important
It contributes towards improving the user experience of Desktop by surfacing instructional information that might be missed otherwise. 