### PR TITLE
Add new attribution page

### DIFF
--- a/content/desktop/authorized.md
+++ b/content/desktop/authorized.md
@@ -1,0 +1,4 @@
+---
+type: authorized
+sitemap_exclude: true
+---

--- a/layouts/authorized/baseof.html
+++ b/layouts/authorized/baseof.html
@@ -1,0 +1,76 @@
+{{- $mixpanelToken := "0897a75fb0160b842eb1218bad4fe322" -}}
+{{- if hugo.IsProduction -}}
+{{- $mixpanelToken = "77dfea682129533729f4dbcd188952e5" -}}
+{{- end -}}
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="robots" content="noindex, nofollow">
+        <script type="text/javascript">
+            const MIXPANEL_CUSTOM_LIB_URL = "https://telemetry.services.testcontainers.cloud/lib.min.js";
+            (function(f,b){if(!b.__SV){var e,g,i,h;window.mixpanel=b;b._i=[];b.init=function(e,f,c){function g(a,d){var b=d.split(".");2==b.length&&(a=a[b[0]],d=b[1]);a[d]=function(){a.push([d].concat(Array.prototype.slice.call(arguments,0)))}}var a=b;"undefined"!==typeof c?a=b[c]=[]:c="mixpanel";a.people=a.people||[];a.toString=function(a){var d="mixpanel";"mixpanel"!==c&&(d+="."+c);a||(d+=" (stub)");return d};a.people.toString=function(){return a.toString(1)+".people (stub)"};i="disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking start_batch_senders people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(" ");
+            for(h=0;h<i.length;h++)g(a,i[h]);var j="set set_once union unset remove delete".split(" ");a.get_group=function(){function b(c){d[c]=function(){call2_args=arguments;call2=[c].concat(Array.prototype.slice.call(call2_args,0));a.push([e,call2])}}for(var d={},e=["get_group"].concat(Array.prototype.slice.call(arguments,0)),c=0;c<j.length;c++)b(j[c]);return d};b._i.push([e,f,c])};b.__SV=1.2;e=f.createElement("script");e.type="text/javascript";e.async=!0;e.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===f.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";g=f.getElementsByTagName("script")[0];g.parentNode.insertBefore(e,g)}})(document,window.mixpanel||[]);
+        </script>    
+    </head>
+    <body>
+        <script>
+            const searchParams = new URLSearchParams(window.location.search);
+            if(searchParams.has('id')){ 
+                const utms = {};
+
+                const referrerCookie = getCookie("__gtm_referrer");
+                if (referrerCookie) {
+                    utms.original_referrer = referrerCookie;
+                }
+
+                const campaignCookie = getCookie("__gtm_campaign_url");
+                if (campaignCookie) {
+                    const url = new URL(campaignCookie);
+                    utms.utm_landing_page = `${url.hostname}${url.pathname}`;
+                    const params = new URLSearchParams(url.search);
+                    const keys = [
+                        "utm_campaign",
+                        "utm_source",
+                        "utm_medium",
+                        "utm_term",
+                        "utm_content"
+                    ]
+                    keys.forEach(key => {
+                        const value = params.get(key) || false;
+                        if (value) {
+                            utms[key] = value;
+                        }
+                    });
+                }
+
+                function getCookie(key) {
+                    var cookies = document.cookie.split(";");
+                    for(var i = 0; i < cookies.length; i++) {
+                        var cookie = cookies[i].split("=");
+                        if(key == cookie[0].trim()) {
+                            return decodeURIComponent(cookie[1]);
+                        }
+                    }
+                    return null;
+                }
+
+                mixpanel.init("{{- $mixpanelToken -}}", {
+                    track_pageview: false,
+                    api_host: "https://telemetry.services.testcontainers.cloud",
+                    disable_persistence: true
+                });
+                mixpanel.track(
+                    "attribution", 
+                    {
+                        installation_id: searchParams.get("id"),
+                        raw_utms: utms,
+                        ...utms
+                    }, 
+                    function() {
+                        window.location.assign("https://app.testcontainers.cloud/");
+                    }
+                );
+            }
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
## What this does
Adds a new page at `/desktop/authorized/` that duplicates the mixpanel attribution from `/event-data/` with a more friendly url and triggers a redirect back to `app.testcontainers.cloud` in the callback of the tracking event.

## Why this is important
Our current attribution implementation relies on cross site cookies. This change allows us to redirect users instead and not run in to cross site issues. 