### PR TITLE
Update authorized attribution to include first touch cookie

### DIFF
--- a/layouts/authorized/baseof.html
+++ b/layouts/authorized/baseof.html
@@ -43,6 +43,8 @@
                     });
                 }
 
+                const firstTouch = getCookie("__gtm_first_touch");
+
                 function getCookie(key) {
                     var cookies = document.cookie.split(";");
                     for(var i = 0; i < cookies.length; i++) {
@@ -63,6 +65,7 @@
                     "attribution", 
                     {
                         installation_id: searchParams.get("id"),
+                        first_touch: firstTouch,
                         raw_utms: utms,
                         ...utms
                     },


### PR DESCRIPTION
## What this does
Updates the mixpanel track event on the `/desktop/authorized/` page to include the value of `__gtm_first_touch` if it is set.

## Why this is important
We want to know how many people with "unknown" attribution (no referrer, no utms) are blocking cookies. This new "first touch" cookie simply saves the timestamp of the users first page view with cookie consent. If it is present we know they have visited testcontainers.com and given cookie consent.