### PR TITLE
Replace GTM url with Cloudflare worker proxy

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,7 +10,7 @@
             <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
             new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
             j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+            'https://tag-manager.testcontainers.com/';f.parentNode.insertBefore(j,f);
             })(window,document,'script','dataLayer','GTM-5LGVXVD');</script>
         <!-- End Google Tag Manager -->
         {{- partial "head.html" . -}}


### PR DESCRIPTION
## What this does
Replaces the url to the Google Tag Manager script with the url of a [Cloudflare worker](https://dash.cloudflare.com/f63a64e586bd3d268acd5a0bb85846f5/workers/services/view/tag-manager/production/triggers) set up to cache and proxy the script through our own domain.

## Why this is important
The analytics on our site are managed through Google Tag Manager. Ad blocking browser plugins like uBlock Origin automatically block the standard GTM script url, leading to users not being requested to give tracking consent and not saving attribution cookies. By proxying the script through our own domain we can sidestep this blocking. 
