### PR TITLE
updated Service Account value to be '30-day free trial' instead of 1

### DIFF
--- a/content/cloud/pricing.md
+++ b/content/cloud/pricing.md
@@ -18,7 +18,7 @@ sections:
       - |
         [Preconfigured Modules](/modules)
       - Max Users (desktop)
-      - Max Service Accounts (CI)
+      - Service Accounts (CI)
       - |
         [Turbo mode](https://knowledge.testcontainers.cloud/turbo-mode)
       - Max Concurrent Workers Per Service Account (CI)
@@ -42,7 +42,7 @@ sections:
             checkmark: true
           - value: 1
             checkmark: false
-          - value: 1
+          - value: 30-day free trial
             checkmark: false
           - value: Not Available
             checkmark: false


### PR DESCRIPTION
Changed info regarding available Service Accounts on the Free plan from '1' to '30-day free trial'
Comes together with https://github.com/AtomicJar/testcontainers-cloud-web/pull/735 