### PR TITLE
Add sessionize link for anton arhipov

### DIFF
--- a/content/community-champions/anton-arhipov.md
+++ b/content/community-champions/anton-arhipov.md
@@ -11,6 +11,9 @@ socialLinks:
   - id: linkedin
     label: antonarhipov
     url: https://www.linkedin.com/in/antonarhipov/
+  - id: sessionize
+    label: Sessionize
+    url: https://sessionize.com/antonarhipov/
 ---
 ## Bio
 Anton Arhipov is a Developer Advocate in the Kotlin team at JetBrains. His professional interests include programming languages and developer tooling. Java Champion since 2014. He has around 20 years of Java development experience.

--- a/content/community-champions/oleg-nenashev.md
+++ b/content/community-champions/oleg-nenashev.md
@@ -14,7 +14,7 @@ socialLinks:
     label: "@oleg_nenashev"
     url: https://twitter.com/oleg_nenashev
   - id: sessionize
-    label: onenashev
+    label: Sessionize
     url: https://sessionize.com/onenashev/
 ---
 ## Bio


### PR DESCRIPTION
## What this does
Adds a sessionize link to the champion page for Anton Arhipov. Also changes the label for the sessionize link on the champion page for Oleg Nenashev.