### PR TITLE
Remove AtomicJar from official modules description

### DIFF
--- a/layouts/modules/list.html
+++ b/layouts/modules/list.html
@@ -95,7 +95,7 @@
                 <svg class="icon-award" width="24" height="24" viewBox="0 0 30 30">
                   <use href="#icon-award"></use>
                 </svg> About Official Modules</h2>
-              <div>AtomicJar partners with software vendors to maintain and certify official modules.</div>
+              <div>We partner with software vendors to maintain and certify official modules.</div>
             </div>
         </div>
         <div class="content">

--- a/layouts/modules/single.html
+++ b/layouts/modules/single.html
@@ -96,7 +96,7 @@
                   <svg class="icon-award" width="24" height="24" viewBox="0 0 30 30">
                     <use href="#icon-award"></use>
                   </svg> Official Modules</h2>
-                <div>AtomicJar partners with software vendors to maintain and certify official modules.</div>
+                <div>We partner with software vendors to maintain and certify official modules.</div>
               </div>
             {{ end }}
 


### PR DESCRIPTION
## What this does
Removes the AtomicJar brand from our description of official modules.