### PR TITLE
Add vector database category to modules

### DIFF
--- a/content/categories/cloud/_index.md
+++ b/content/categories/cloud/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Cloud
 slug: cloud
-weight: 4
+weight: 6
 ---

--- a/content/categories/message-broker/_index.md
+++ b/content/categories/message-broker/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Message Broker
 slug: message-broker
-weight: 3
+weight: 4
 ---

--- a/content/categories/vector-database/_index.md
+++ b/content/categories/vector-database/_index.md
@@ -1,0 +1,5 @@
+---
+title: Vector Database
+slug: vector-database
+weight: 3
+---

--- a/content/modules/_example.md.example
+++ b/content/modules/_example.md.example
@@ -6,6 +6,7 @@ isOfficial: false
 categories:
   - relational-database
   - nosql-database
+  - vector-database
   - message-broker
   - cloud
   - web

--- a/content/modules/elasticsearch.md
+++ b/content/modules/elasticsearch.md
@@ -2,6 +2,7 @@
 title: Elasticsearch
 categories:
   - nosql-database
+  - vector-database
 docs:
   - id: java
     url: https://java.testcontainers.org/modules/elasticsearch/

--- a/content/modules/postgresql.md
+++ b/content/modules/postgresql.md
@@ -2,6 +2,7 @@
 title: PostgreSQL
 categories:
   - relational-database
+  - vector-database
 docs:
   - id: java
     url: https://java.testcontainers.org/modules/databases/postgres/

--- a/content/modules/redis.md
+++ b/content/modules/redis.md
@@ -2,6 +2,7 @@
 title: Redis
 categories:
   - nosql-database
+  - vector-database
 docs:
   - id: java
     url: https://github.com/redis-developer/testcontainers-redis


### PR DESCRIPTION
## What this does
Adds a `Vector Database` category to the modules catalogue and updates the relevant modules

## Why this is important
Highlighting vector DBs supports the push to popularise Testcontainers in AI development workflows. 