### PR TITLE
Upgrade Hugo from 0.109.0 to 0.123.1

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,8 +18,10 @@
 {{ $langaugesData := .Site.Data.languages }}
 {{ $pageDocs := .Page.Params.Docs }}
 {{ $siteBaseUrl := .Site.BaseURL }}
-{{ $fileBaseName := .File.BaseFileName }}
-
+{{ $fileBaseName := "default" }}
+{{ with .File }}
+    {{ $fileBaseName = .BaseFileName }}
+{{ end }}
 {{ $ogTitle := .Site.Title }}
 {{ $ogDescription := .Site.Params.Description }}
 {{ $ogImage := printf "%s/images/share-image.png" $siteBaseUrl }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@
 
 # The Production Context applies to the branch you have configured as main branch to deploy:
 [context.production.environment]
-    HUGO_VERSION = "0.109.0"
+    HUGO_VERSION = "0.123.1"
     HUGO_ENV = "production"
 
 # The Deploy Preview Context applies to every Deploy Preview you create:
@@ -16,14 +16,14 @@
     command = "chmod +x build.sh && ./build.sh -b $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
-    HUGO_VERSION = "0.109.0"
+    HUGO_VERSION = "0.123.1"
 
 [context.branch-deploy]
     command = "chmod +x build.sh && ./build.sh -b $DEPLOY_PRIME_URL"
 
 # The Branch Deploy Context applies to all non-master branches deployed, whether they are in a Deploy Preview or not:
 [context.branch-deploy.environment]
-    HUGO_VERSION = "0.109.0"
+    HUGO_VERSION = "0.123.1"
 
 [[redirects]]
     from = "/guides/guide/*"


### PR DESCRIPTION
## What this does
Upgrades Hugo from 0.109.0 to 0.123.1

## Why this is important
0.109.0 was published on Dec 23, 2022, this PR pulls in 14 months of new features and bug fixes. 