### PR TITLE
chore: use library instead of framework in the index

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -3,7 +3,7 @@ title: Testcontainers
 sections:
   - partial: hero-banner
     title: Unit tests with real dependencies
-    description: Testcontainers is an open source framework for providing throwaway, lightweight instances of databases, message brokers, web browsers, or just about anything that can run in a Docker container.
+    description: Testcontainers is an open source library for providing throwaway, lightweight instances of databases, message brokers, web browsers, or just about anything that can run in a Docker container.
   - partial: code-examples
     small_title: How it works
     title: Test dependencies as code

--- a/content/cloud/_index.md
+++ b/content/cloud/_index.md
@@ -60,7 +60,7 @@ sections:
         image: /images/quotes/roberto-perez-alcolea.jpg
   - partial: experience-columns
     title: Full Testcontainers Experience
-    description: Testcontainers is an open source framework for providing throwaway, lightweight instances of databases, message brokers, web browsers, or just about anything that can run in a Docker container. Testcontainers Cloud lets you have the same great experience wherever you are running your tests.
+    description: Testcontainers is an open source library for providing throwaway, lightweight instances of databases, message brokers, web browsers, or just about anything that can run in a Docker container. Testcontainers Cloud lets you have the same great experience wherever you are running your tests.
     columns:
       - icon: testcontainers
         title: Unit Tests With Real Dependencies


### PR DESCRIPTION
This is the main window for anybody trying to learn from the project, just because they want to read about Testcontainers libraries, or just understand a CfP submission in order to accept or reject a talk based on the project website 🤷‍♂️.

I have a feeling that the Go community is highly reticent to that "framework" word, and for that I'm changing it.

I remember @ekcasey using "the F word".

I think this change is easy to merge as everybody has agreed on the change when we discussed it on slack, although I never worked it.