### PR TITLE
feat: support using a PR from the community site

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
 
     The guides and modules are maintained in separate repositories. If you want to preview the site with that content during development this script will clone and process it.
 
+    It's possible to run the site for a pull request in the `Community Module Registry` repository by running `COMMUNITY_MODULE_PR=<PR_NUMBER> sh dev.sh`. This will clone the repository and checkout the PR branch.
+
 2. **Run the local server**
 
     Run `hugo serve` to bring up a local development server that will watch changes and serve a preview at http://localhost:1313/ 

--- a/build.sh
+++ b/build.sh
@@ -3,11 +3,21 @@
 GIT_ORG="https://github.com/testcontainers"
 echo "----------------- Downloading Community modules -----------------"
 COMMUNITY_MODULE_REPO="community-module-registry"
+# PR number to checkout: If not set, it will checkout the latest commit
+COMMUNITY_MODULE_PR="${COMMUNITY_MODULE_PR:-}"
 
 rm -rf ${COMMUNITY_MODULE_REPO}
 
 echo "Cloning ${GIT_ORG}/${COMMUNITY_MODULE_REPO}.git"
 git clone "${GIT_ORG}/${COMMUNITY_MODULE_REPO}.git"
+
+if [ -n "${COMMUNITY_MODULE_PR}" ]; then
+  echo "Checking out PR: ${COMMUNITY_MODULE_PR}"
+  cd ${COMMUNITY_MODULE_REPO}
+  git fetch origin pull/${COMMUNITY_MODULE_PR}/head:pr-${COMMUNITY_MODULE_PR}
+  git checkout pr-${COMMUNITY_MODULE_PR}
+  cd ..
+fi
 
 echo "---------------- Downloading Guides -----------------------------"
 GUIDE_REPOS=(

--- a/dev.sh
+++ b/dev.sh
@@ -3,11 +3,21 @@ GIT_ORG="https://github.com/testcontainers"
 
 echo "----------------- Downloading Community modules -----------------"
 COMMUNITY_MODULE_REPO="community-module-registry"
+# PR number to checkout: If not set, it will checkout the latest commit
+COMMUNITY_MODULE_PR="${COMMUNITY_MODULE_PR:-}"
 
 rm -rf ${COMMUNITY_MODULE_REPO}
 
 echo "Cloning ${GIT_ORG}/${COMMUNITY_MODULE_REPO}.git"
 git clone "${GIT_ORG}/${COMMUNITY_MODULE_REPO}.git"
+
+if [ -n "${COMMUNITY_MODULE_PR}" ]; then
+  echo "Checking out PR: ${COMMUNITY_MODULE_PR}"
+  cd ${COMMUNITY_MODULE_REPO}
+  git fetch origin pull/${COMMUNITY_MODULE_PR}/head:pr-${COMMUNITY_MODULE_PR}
+  git checkout pr-${COMMUNITY_MODULE_PR}
+  cd ..
+fi
 
 echo "---------------- Downloading Guides -----------------------------"
 GUIDE_REPOS=(


### PR DESCRIPTION
- **fix: typos**
- **feat: support using a PR in the community module**

## What does this PR do?
It allows contributors of the site to fetch the community-modules repo in a given PR, which is handy to verify the state of the site with the given PR.

## How to run this?

```
COMMUNITY_MODULE_PR=43 ./dev.sh
hugo serve
```

The expected outcome would be that the community-site repository will be in the branch for that PR, so the changes will be incorporated to the local site.
