### PR TITLE
chore: use same Hugo version as in production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,13 @@
 # - Port for the website, default is 1313
 # - Community Modules Site PR, default is empty
 # - Container name, default is testcontainers-site
+# - Hugo version override, default is 0.123.1
 # - Community Modules Site path, default is empty, in case you want to use a local version of the community modules site.
 NODE_VERSION ?= 20.3.0
 PORT ?= 1313
 COMMUNITY_MODULE_PR ?=
 CONTAINER_NAME ?= testcontainers-site
+HUGO_VERSION_OVERRIDE ?= 0.123.1
 COMMUNITY_MODULE_PATH ?=
 COMMUNITY_MODULE_VOLUME =
 ifneq ($(COMMUNITY_MODULE_PATH),)
@@ -35,6 +37,7 @@ run:
 	@echo "$(COMMUNITY_MODULE_VOLUME)"
 	@docker run --rm -d \
 		--name $(CONTAINER_NAME) \
+		-e "HUGO_VERSION_OVERRIDE=$(HUGO_VERSION_OVERRIDE)" \
 		-p $(PORT):1313 \
 		-v "$(CURDIR)/archetypes:/src/archetypes" \
 		-v "$(CURDIR)/assets:/src/assets" \


### PR DESCRIPTION
The docker image for Hugo supports overriding the version with the `HUGO_VERSION_OVERRIDE` env var (see https://hub.docker.com/r/klakegg/hugo)

Because the Docker image uses 0.111.3 (see Dockerfile), Netlify uses 0.123.3 (see any deployment log), and there is no other most recent image (see Dockerhub),
we need to use this mechanism to match versions.

I noticed this after running the site locally. Before this change, the container died with:

```
Start building sites … 
hugo v0.111.3-5d4eb5154e1fed125ca8e9b5a0315c4180dab192+extended linux/amd64 BuildDate=2023-03-12T11:40:50Z VendorInfo=hugoguru
ERROR 2024/07/19 06:44:49 render of "page" failed: "/src/layouts/_default/baseof.html:16:8": execute of template failed: template: modules/single.html:16:8: executing "modules/single.html" at <partial "head.html" .>: error calling partial: "/src/layouts/partials/head.html:16:3": execute of template failed: template: partials/head.html:16:3: executing "partials/head.html" at <partial "meta" .>: error calling partial: "/src/layouts/partials/meta.html:3:13": execute of template failed: template: partials/meta.html:3:13: executing "partials/meta.html" at <partial "utils/share-image" .>: error calling partial: "/src/layouts/partials/utils/share-image.html:71:17": execute of template failed: template: partials/utils/share-image.html:71:17: executing "partials/utils/share-image.html" at <$categoriesString>: wrong type for value; expected string; got template.HTML
ERROR 2024/07/19 06:44:49 render of "page" failed: "/src/layouts/_default/baseof.html:16:8": execute of template failed: template: modules/single.html:16:8: executing "modules/single.html" at <partial "head.html" .>: error calling partial: "/src/layouts/partials/head.html:16:3": execute of template failed: template: partials/head.html:16:3: executing "partials/head.html" at <partial "meta" .>: error calling partial: "/src/layouts/partials/meta.html:3:13": execute of template failed: template: partials/meta.html:3:13: executing "partials/meta.html" at <partial "utils/share-image" .>: error calling partial: "/src/layouts/partials/utils/share-image.html:71:17": execute of template failed: template: partials/utils/share-image.html:71:17: executing "partials/utils/share-image.html" at <$categoriesString>: wrong type for value; expected string; got template.HTML
ERROR 2024/07/19 06:44:49 render of "page" failed: "/src/layouts/_default/baseof.html:16:8": execute of template failed: template: modules/single.html:16:8: executing "modules/single.html" at <partial "head.html" .>: error calling partial: "/src/layouts/partials/head.html:16:3": execute of template failed: template: partials/head.html:16:3: executing "partials/head.html" at <partial "meta" .>: error calling partial: "/src/layouts/partials/meta.html:3:13": execute of template failed: template: partials/meta.html:3:13: executing "partials/meta.html" at <partial "utils/share-image" .>: error calling partial: "/src/layouts/partials/utils/share-image.html:71:17": execute of template failed: template: partials/utils/share-image.html:71:17: executing "partials/utils/share-image.html" at <$categoriesString>: wrong type for value; expected string; got template.HTML
ERROR 2024/07/19 06:44:49 render of "page" failed: "/src/layouts/_default/baseof.html:16:8": execute of template failed: template: modules/single.html:16:8: executing "modules/single.html" at <partial "head.html" .>: error calling partial: "/src/layouts/partials/head.html:16:3": execute of template failed: template: partials/head.html:16:3: executing "partials/head.html" at <partial "meta" .>: error calling partial: "/src/layouts/partials/meta.html:3:13": execute of template failed: template: partials/meta.html:3:13: executing "partials/meta.html" at <partial "utils/share-image" .>: error calling partial: "/src/layouts/partials/utils/share-image.html:71:17": execute of template failed: template: partials/utils/share-image.html:71:17: executing "partials/utils/share-image.html" at <$categoriesString>: wrong type for value; expected string; got template.HTML
Error: Error building site: failed to render pages: render of "page" failed: "/src/layouts/_default/baseof.html:16:8": execute of template failed: template: modules/single.html:16:8: executing "modules/single.html" at <partial "head.html" .>: error calling partial: "/src/layouts/partials/head.html:16:3": execute of template failed: template: partials/head.html:16:3: executing "partials/head.html" at <partial "meta" .>: error calling partial: "/src/layouts/partials/meta.html:3:13": execute of template failed: template: partials/meta.html:3:13: executing "partials/meta.html" at <partial "utils/share-image" .>: error calling partial: "/src/layouts/partials/utils/share-image.html:71:17": execute of template failed: template: partials/utils/share-image.html:71:17: executing "partials/utils/share-image.html" at <$categoriesString>: wrong type for value; expected string; got template.HTML
Built in 4754 ms
```

Therefore I went to the production URL to check if the deployment of the PRs merged today were broken. They weren't, so I checked the version in Netlify. And with that version, everything works again, so Hugo must have changed something in between.

As a side effect, in the Github settings for the pull requests, I enabled the `Update PR` button, so that we can have the preview of a given PRs after merging with main.
