### PR TITLE
Fix web app login after desktop auth tracking redirect

### DIFF
--- a/layouts/authorized/baseof.html
+++ b/layouts/authorized/baseof.html
@@ -73,7 +73,7 @@
             send_immediately: true
           },
           function() {
-            window.location.assign("https://app.testcontainers.cloud/");
+            window.location.assign("https://app.testcontainers.cloud/api/auth/login");
           }
         );
       }


### PR DESCRIPTION
## What this does
When we changed the login page from the Auth0 hosted page to the new proxy page in the web app the silent login after redirecting to index stopped working. 

By redirecting to the api login endpoint instead, users should be correctly authed in the web app.