### PR TITLE
Allow linking to pages with a specific language code example active

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -48,35 +48,54 @@ const allTabLabels = document.querySelectorAll(".code-examples .tab-labels butto
 allTabLabels.forEach((label) => {
   label.addEventListener("click", (e) => {
     const targetId = e.currentTarget.dataset.target;
-
-    const tabLabels = e.currentTarget.closest(".examples").querySelectorAll(".tab-labels button");
-    tabLabels.forEach((label) => {
-      if (label.dataset.target === targetId) {
-        label.classList.add("active");
-      } else {
-        label.classList.remove("active");
-      }
-    });
-
-    const tabPanels = e.target.closest(".examples").querySelectorAll(".tab-panels .tab-panel");
-    tabPanels.forEach((panel) => {
-      if (panel.dataset.id === targetId) {
-        panel.classList.add("active");
-      } else {
-        panel.classList.remove("active");
-      }
-    });
-
-    const gettingStartedButtons = e.target.closest(".code-examples").querySelectorAll(".getting-started-button");
-    gettingStartedButtons.forEach((button) => {
-      if (button.dataset.id === targetId) {
-        button.classList.add("active");
-      } else {
-        button.classList.remove("active");
-      }
-    });
+    setQueryParam("language", targetId);
+    setActiveTab(targetId);
   });
 });
+
+const languageQuery = new URL(window.location.href).searchParams.get('language');
+if (languageQuery) {
+  setActiveTab(languageQuery);
+}
+
+function setActiveTab(targetId) {
+  const tabLabels = document.querySelectorAll(".code-examples .tab-labels button");
+
+  if ([...tabLabels].filter(label => label.dataset.target === targetId).length === 0) 
+    return;
+
+  tabLabels.forEach((label) => {
+    if (label.dataset.target === targetId) {
+      label.classList.add("active");
+    } else {
+      label.classList.remove("active");
+    }
+  });
+
+  const tabPanels = document.querySelectorAll(".code-examples .tab-panels .tab-panel");
+  tabPanels.forEach((panel) => {
+    if (panel.dataset.id === targetId) {
+      panel.classList.add("active");
+    } else {
+      panel.classList.remove("active");
+    }
+  });
+
+  const gettingStartedButtons = document.querySelectorAll(".code-examples .getting-started-button");
+  gettingStartedButtons.forEach((button) => {
+    if (button.dataset.id === targetId) {
+      button.classList.add("active");
+    } else {
+      button.classList.remove("active");
+    }
+  });
+}
+
+function setQueryParam(param, value) {
+  const url = new URL(window.location.href);
+  url.searchParams.set(param, value);
+  history.replaceState(history.state, "", url.href);
+}
 
 // Handle UTMs
 const utms = [];

--- a/assets/js/modules.js
+++ b/assets/js/modules.js
@@ -107,9 +107,22 @@ function handleFilterToggle() {
   document.body.classList.toggle('filter-toggled');
 }
 
+function handleModuleLinkClick(e) {
+  const pageUrl = new URL(window.location.href);
+  const language = pageUrl.searchParams.get('language');
+  if (language) {
+    const url = new URL(e.currentTarget.href);
+    url.searchParams.set('language', language);
+    e.currentTarget.href = url.href;
+  }
+}
+
+all.forEach((moduleItem) => {
+  moduleItem.addEventListener('click', handleModuleLinkClick);
+});
 inputs.forEach((input) => {
   input.addEventListener('change', showFilterResults);
-})
+});
 search.addEventListener('keyup', showFilterResults);
 clearFilter.addEventListener('click', clearTheFilter);
 filterToggle.addEventListener('click', handleFilterToggle);

--- a/layouts/modules/list.html
+++ b/layouts/modules/list.html
@@ -5,7 +5,7 @@
     {{ $guidesstyle := resources.Get "/sass/guides.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}
     <link rel="stylesheet" href="{{ $guidesstyle.RelPermalink }}">
 
-    {{ $script := resources.Get "/js/modules.js" | js.Build | resources.Minify }}
+    {{ $script := resources.Get "/js/modules.js" | js.Build | resources.Minify | resources.Fingerprint }}
     <script src="{{ $script.RelPermalink }}" defer></script>
 {{ end }}
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,7 +5,7 @@
 <link rel="stylesheet" href="{{ $style.RelPermalink }}">
 
 <script src="/js/highlight.min.js" defer></script>
-{{ $script := resources.Get "/js/main.js" | resources.Minify }}
+{{ $script := resources.Get "/js/main.js" | resources.Minify | resources.Fingerprint }}
 <script src="{{ $script.RelPermalink }}" defer></script>
 
 <link rel="icon" href="/favicon.ico" sizes="any">

--- a/layouts/partials/sections/code-examples.html
+++ b/layouts/partials/sections/code-examples.html
@@ -25,13 +25,16 @@
           {{ $buttonClasses := "getting-started-button" }}
           {{ if eq $index 0 }}
             {{ $buttonClasses = print $buttonClasses " active" }}
-            {{ end }}
-            <a class="{{ $buttonClasses }}" data-id="{{ $example.id }}" href="{{ $example.url }}" {{ if $example.external
-              }}target="_bank" {{ end }}>
+          {{ end }}
+          {{ $buttonLanguage := "" }}
+          {{ with index site.Data.languages $example.id }}
+            {{ $buttonLanguage = .title }}
+          {{ end }}
+            <a class="{{ $buttonClasses }}" data-id="{{ $example.id }}" href="{{ $example.url }}" {{ if $example.external }}target="_bank" {{ end }}>
               {{ if $example.icon }}
                 {{ partial "img.html" (dict "image" (resources.Get $example.icon) "alt" "") }}
               {{ end }}
-              Get started with {{ $example.label }}
+              Get started with {{ $buttonLanguage }}
               {{ if $example.external }}
                 <svg class="icon-external" width="15" height="17" viewBox="0 0 15 17">
                   <use href="#icon-external"></use>


### PR DESCRIPTION
## What this does

As requested in https://github.com/testcontainers/testcontainers-site/issues/220 this PR allows you to preselect the code example on any page that uses the `code-example` block by adding the `language=LANGUAGE_ID` query parameter. 

When browsing the modules list with a language filter active, clicking a module will load the page with the active language filter set.

![image](https://github.com/user-attachments/assets/35c5832d-c286-49dc-977c-da0f5e35cbe6)
![image](https://github.com/user-attachments/assets/cfbdfa04-33f1-40c0-bb84-1e5979d9881f)

Additionally this fixes a bug where the code examples getting started buttons on the index page did not display the language titles as they should.

Before:
![image](https://github.com/user-attachments/assets/f36f71b8-6f56-4c6e-8ca7-a8e9a3adfc28)
After:
![image](https://github.com/user-attachments/assets/3f20e620-2888-4073-ac4a-643823707c6d)
