### PR TITLE
feat: support for rust modules

### DIFF
--- a/content/modules/_index.md
+++ b/content/modules/_index.md
@@ -6,4 +6,5 @@ languages:
   - go
   - dotnet
   - nodejs
+  - rust
 ---

--- a/layouts/modules/list.html
+++ b/layouts/modules/list.html
@@ -10,7 +10,7 @@
 {{ end }}
 
 {{ define "main" }}
-  {{- $filterLanguages := slice "java" "dotnet" "go" "nodejs" -}}
+  {{- $filterLanguages := slice "java" "dotnet" "go" "nodejs" "rust" -}}
   <main>
     <section class="modules-banner">
         <div class="container">


### PR DESCRIPTION
This PR adds the rust language to the modules catalog filter:

- in the index.md file
- in the list.html module layout, in order to include it in the filters.

Closes #204 

### Render
URL: https://deploy-preview-227--testcontainers-site.netlify.app/modules/?language=rust

<img width="1420" alt="Screenshot 2024-09-20 at 11 34 26" src="https://github.com/user-attachments/assets/08deec76-b66d-4483-94d1-681fbca31923">