### PR TITLE
Redirect to app root after authorized tracking

### DIFF
--- a/layouts/authorized/baseof.html
+++ b/layouts/authorized/baseof.html
@@ -9,7 +9,7 @@
     <script type="text/javascript">
       const MIXPANEL_CUSTOM_LIB_URL = "https://telemetry.svc.testcontainers.cloud/lib.min.js";
       function redirectToDashboard() {
-        const redirectUrl = new URL("https://app.testcontainers.cloud/api/auth/login");
+        const redirectUrl = new URL("https://app.testcontainers.cloud");
         const account = new URLSearchParams(window.location.search).get("account");
         if (account) {
           redirectUrl.searchParams.append("account", account);


### PR DESCRIPTION
## What this does

Changes the post-authorized-tracking redirect path to the webapp from `/api/auth/login` to `/`

This change was initially added due to issues with users not being silently authed with the web app after authorization and seeing the login page.

However it currently means that users are not directed to the correct account context after authorization so we are testing reverting it and seeing how it goes.  