### PR TITLE
Redirect to auth with an account returnto

### DIFF
--- a/layouts/authorized/baseof.html
+++ b/layouts/authorized/baseof.html
@@ -9,11 +9,11 @@
     <script type="text/javascript">
       const MIXPANEL_CUSTOM_LIB_URL = "https://telemetry.svc.testcontainers.cloud/lib.min.js";
       function redirectToDashboard() {
-        const redirectUrl = new URL("https://app.testcontainers.cloud");
+        const redirectUrl = new URL("https://app.testcontainers.cloud/api/auth/login");
         const account = new URLSearchParams(window.location.search).get("account");
         if (account) {
-          redirectUrl.searchParams.append("account", account);
-        }
+          redirectUrl.searchParams.append("returnTo", "login?returnTo=" + encodeURIComponent(`/?account=${account}`))
+        } 
         window.location.assign(redirectUrl);
       }
       (function(f,b){if(!b.__SV){var e,g,i,h;window.mixpanel=b;b._i=[];b.init=function(e,f,c){function g(a,d){var b=d.split(".");2==b.length&&(a=a[b[0]],d=b[1]);a[d]=function(){a.push([d].concat(Array.prototype.slice.call(arguments,0)))}}var a=b;"undefined"!==typeof c?a=b[c]=[]:c="mixpanel";a.people=a.people||[];a.toString=function(a){var d="mixpanel";"mixpanel"!==c&&(d+="."+c);a||(d+=" (stub)");return d};a.people.toString=function(){return a.toString(1)+".people (stub)"};i="disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking start_batch_senders people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(" ");


### PR DESCRIPTION
## What this does

Quick test to see if this approach to fixing the TCD auth redirect account selection issue works before we disabled the attribution redirect.