### PR TITLE
Add Scala, reorder languages, update PHP docs link

### DIFF
--- a/assets/images/language-logos/scala.svg
+++ b/assets/images/language-logos/scala.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml-stylesheet href="sp-styles.css" type="text/css"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 350 550" preserveAspectRatio="xMidYMid meet">
+	<title>Scala</title>
+	<desc>The Scala Logo</desc>
+	<defs>
+		<linearGradient id="red-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+			<stop offset="0%" style="stop-color:rgb(160,0,0);stop-opacity:1" />
+			<stop offset="100%" style="stop-color:rgb(255,0,0);stop-opacity:1" />
+		</linearGradient>
+		<linearGradient id="grey-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+			<stop offset="0%" style="stop-color:rgb(100,100,100);stop-opacity:1" />
+			<stop offset="100%" style="stop-color:rgb(0,0,0);stop-opacity:1" />
+		</linearGradient>
+	</defs>
+	<g cx="200" cy="70" rx="85" ry="55" fill="url(#grey-gradient)">
+		<path d="m 30,80 c 0,0 300,-30 300,-80 l 0,120 c 0,0 0,50 -300,80 l 0,120 z" transform="matrix(1 0 0 -1 0 280)"/>
+		<path d="m 30,80 c 0,0 300,-30 300,-80 l 0,120 c 0,0 0,50 -300,80 l 0,120 z" transform="matrix(1 0 0 -1 0 440)"/>
+	</g>
+	<g cx="200" cy="70" rx="85" ry="55" fill="url(#red-gradient)">
+		<path d="m 30,80 c 0,0 300,-30 300,-80 l 0,120 c 0,0 0,50 -300,80 l 0,120 z"/>
+		<path d="m 30,240 c 0,0 300,-30 300,-80 l 0,120 c 0,0 0,50 -300,80 l 0,120 z"/>
+		<path d="m 30,400 c 0,0 300,-30 300,-80 l 0,120 c 0,0 0,50 -300,80 l 0,120 z"/>
+	</g>
+</svg>

--- a/assets/images/language-logos/scala.svg
+++ b/assets/images/language-logos/scala.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?xml-stylesheet href="sp-styles.css" type="text/css"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 350 550" preserveAspectRatio="xMidYMid meet">
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 350 550" preserveAspectRatio="xMidYMid meet">
 	<title>Scala</title>
 	<desc>The Scala Logo</desc>
 	<defs>

--- a/data/languages.yml
+++ b/data/languages.yml
@@ -22,25 +22,29 @@ nodejs:
   logo: /images/language-logos/nodejs.svg
   link: https://node.testcontainers.org/
   order: 3
-c:
-  slug: c
-  title: C/C++
+python:
+  slug: python
+  title: Python
+  logo: /images/language-logos/python.svg
+  link: https://testcontainers-python.readthedocs.io/en/latest/
   order: 4
-clojure:
-  slug: clojure
-  title: Clojure
-  logo: /images/language-logos/clojure.svg
-  link: https://cljdoc.org/d/clj-test-containers/clj-test-containers/
+rust:
+  slug: rust
+  title: Rust
+  logo: /images/language-logos/rust.svg
+  link: https://rust.testcontainers.org/
   order: 5
-csharp:
-  slug: csharp
-  title: C#
+ruby:
+  slug: ruby
+  title: Ruby
+  logo: /images/language-logos/ruby.svg
+  link: https://github.com/testcontainers/testcontainers-ruby
   order: 6
-elixir:
-  slug: elixir
-  title: Elixir
-  logo: /images/language-logos/elixir.svg
-  link: https://github.com/testcontainers/testcontainers-elixir
+php:
+  slug: php
+  title: PHP
+  logo: /images/language-logos/php.svg
+  link: https://php.testcontainers.org
   order: 7
 haskell:
   slug: haskell
@@ -48,38 +52,40 @@ haskell:
   logo: /images/language-logos/haskell.svg
   link: https://github.com/testcontainers/testcontainers-hs
   order: 8
-kotlin:
-  slug: kotlin
-  title: Kotlin
-  logo: /images/language-logos/kotlin.svg
+clojure:
+  slug: clojure
+  title: Clojure
+  logo: /images/language-logos/clojure.svg
+  link: https://cljdoc.org/d/clj-test-containers/clj-test-containers/
   order: 9
-python:
-  slug: python
-  title: Python
-  logo: /images/language-logos/python.svg
-  link: https://testcontainers-python.readthedocs.io/en/latest/
+elixir:
+  slug: elixir
+  title: Elixir
+  logo: /images/language-logos/elixir.svg
+  link: https://github.com/testcontainers/testcontainers-elixir
   order: 10
-ruby:
-  slug: ruby
-  title: Ruby
-  logo: /images/language-logos/ruby.svg
-  link: https://github.com/testcontainers/testcontainers-ruby
+scala:
+  slug: scala
+  title: Scala
+  logo: /images/language-logos/scala.svg
+  link: https://github.com/testcontainers/testcontainers-scala/
   order: 11
-rust:
-  slug: rust
-  title: Rust
-  logo: /images/language-logos/rust.svg
-  link: https://rust.testcontainers.org/
-  order: 12
-php:
-  slug: php
-  title: PHP
-  logo: /images/language-logos/php.svg
-  link: https://github.com/testcontainers/testcontainers-php
-  order: 13
 native:
   slug: native
   title: Native
   logo: /images/language-logos/c.svg
   link: https://github.com/testcontainers/testcontainers-native
+  order: 12
+c:
+  slug: c
+  title: C/C++
+  order: 13
+csharp:
+  slug: csharp
+  title: C#
   order: 14
+kotlin:
+  slug: kotlin
+  title: Kotlin
+  logo: /images/language-logos/kotlin.svg
+  order: 15


### PR DESCRIPTION
- Reorder all languages to: Java, Go, .NET, Node.js, Python, Rust, Ruby, PHP, Haskell, Clojure, Elixir, Scala, Native
- Add Scala entry with logo
- Update PHP docs link to https://php.testcontainers.org